### PR TITLE
Create Dead Letter Queue Worker

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -73,19 +73,23 @@ phases:
       - zip -u package-aws.zip moj.crt moj.key elk-ca.crt
       # build templates
       - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-cloudwatch-syslog > cf-$ENV-cloudwatch-syslog.json
-      - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-cloudwatch > cf-$ENV-cloudwatch.json
-      - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-sqs        > cf-$ENV-sqs.json
-      - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-kinesis    > cf-$ENV-kinesis.json
+      - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-cloudwatch  > cf-$ENV-cloudwatch.json
+      - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-sqs         > cf-$ENV-sqs.json
+      - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-kinesis     > cf-$ENV-kinesis.json
+      - ./functionbeat -e -c ../functionbeat-config.yml export function staff-device-$ENV-infra-dead-letter > cf-$ENV-dlq.json
 
       # upload lambdas
       - export CW_SYSLOG_S3_KEY=`cat cf-$ENV-cloudwatch-syslog.json | jq -r '.. |."S3Key"? | select(. != null)'`
       - export CW_S3_KEY=`cat cf-$ENV-cloudwatch.json | jq -r '.. |."S3Key"? | select(. != null)'`
       - export SQS_S3_KEY=`cat cf-$ENV-sqs.json       | jq -r '.. |."S3Key"? | select(. != null)'`
       - export KINESIS_S3_KEY=`cat cf-$ENV-kinesis.json | jq -r '.. |."S3Key"? | select(. != null)'`
+      - export DLQ_SQS_S3_KEY=`cat cf-$ENV-dlq.json       | jq -r '.. |."S3Key"? | select(. != null)'`
+
       - aws s3 cp --no-progress ./package-aws.zip s3://staff-device-$ENV-infra-functionbeat-artifacts/$CW_SYSLOG_S3_KEY
       - aws s3 cp --no-progress ./package-aws.zip s3://staff-device-$ENV-infra-functionbeat-artifacts/$CW_S3_KEY
       - aws s3 cp --no-progress ./package-aws.zip s3://staff-device-$ENV-infra-functionbeat-artifacts/$SQS_S3_KEY
       - aws s3 cp --no-progress ./package-aws.zip s3://staff-device-$ENV-infra-functionbeat-artifacts/$KINESIS_S3_KEY
+      - aws s3 cp --no-progress ./package-aws.zip s3://staff-device-$ENV-infra-functionbeat-artifacts/$DLQ_SQS_S3_KEY
       # upload templates
       - |
         aws cloudformation deploy \
@@ -106,6 +110,11 @@ phases:
         aws cloudformation deploy \
           --stack-name staff-device-$ENV-infra-kinesis \
           --template-file ./cf-$ENV-kinesis.json \
+          --no-fail-on-empty-changeset
+      - |
+        aws cloudformation deploy \
+          --stack-name staff-device-$ENV-infra-dlq \
+          --template-file ./cf-$ENV-dlq.json \
           --no-fail-on-empty-changeset
 
       # ensure log retention period is set for all CloudWatch logs

--- a/modules/function_beats_config/main.tf
+++ b/modules/function_beats_config/main.tf
@@ -10,10 +10,11 @@ locals {
     }
   ]
 
-  cloudwatch_syslog_name = "${var.prefix}-cloudwatch-syslog"
-  cloudwatch_name        = "${var.prefix}-cloudwatch"
-  sqs_name               = "${var.prefix}-sqs"
-  kinesis_name           = "${var.prefix}-kinesis"
+  cloudwatch_syslog_name         = "${var.prefix}-cloudwatch-syslog"
+  cloudwatch_name                = "${var.prefix}-cloudwatch"
+  sqs_name                       = "${var.prefix}-sqs"
+  kinesis_name                   = "${var.prefix}-kinesis"
+  dead_letter_queue_shipper_name = "${var.prefix}-dlq"
 
   config = yamlencode({
     "functionbeat.provider.aws.endpoint" : "s3.amazonaws.com"
@@ -158,6 +159,33 @@ locals {
               add_error_key : true,
               overwrite_keys : true,
               max_depth : 10
+            }
+          }
+        ]
+      },
+      {
+        name : local.dead_letter_queue_shipper_name,
+        concurrency: 10,
+        enabled : false,
+        type : "sqs",
+        timeout: "8s",
+        description : "lambda function to process the dead letter queue, this function should only be enabled as a onceoff to process failed messages",
+        role : var.deploy_role_arn,
+        tags: {
+          data_source: "dead_letter_queue"
+        },
+        virtual_private_cloud : {
+          security_group_ids : var.security_group_ids
+          subnet_ids : var.subnet_ids
+        },
+        triggers : [
+          { event_source_arn : var.beats_dead_letter_queue_arn }
+        ],
+        processors : [
+          {
+            add_tags : {
+              tags: ["sqs"]
+              target : "log_source"
             }
           }
         ]


### PR DESCRIPTION
This is an instance of Functionbeat that will process the dead letter
SQS queue.

This will only be enabled for messages that failed to send and ended up
on the queue.

It has no dead letter queue itself so if messages failed to send again,
they would be lost.