### PR TITLE
Ability to process failed messages on Dead Letter Queue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ apply-pre-production:
 apply-production:
 	./scripts/apply_environment production
 
+process-dead-letter-queue:
+	./scripts/process_dead_letter_queue
+
 init:
 	terraform init --backend-config="key=terraform.development.state" -reconfigure -upgrade
 

--- a/scripts/disaster_recovery/Dockerfile
+++ b/scripts/disaster_recovery/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.8-alpine3.12
+WORKDIR /code
+
+COPY process_dlq.py process_dlq.py
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+CMD ["python", "process_dlq.py"]

--- a/scripts/disaster_recovery/process_dlq.py
+++ b/scripts/disaster_recovery/process_dlq.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+"""
+Move all the messages from one SQS queue to another.
+
+Usage: Run from Makefile. Run make process-dead-letter-queue and add required values
+"""
+
+import boto3
+import itertools
+import os
+import sys
+import uuid
+
+def get_messages_from_queue(sqs_client, queue_url):
+    while True:
+        resp = sqs_client.receive_message(
+            QueueUrl=queue_url, AttributeNames=["All"], MaxNumberOfMessages=10
+        )
+
+        try:
+            yield from resp["Messages"]
+        except KeyError:
+            return
+
+        entries = [
+            {"Id": msg["MessageId"], "ReceiptHandle": msg["ReceiptHandle"]}
+            for msg in resp["Messages"]
+        ]
+
+        resp = sqs_client.delete_message_batch(QueueUrl=queue_url, Entries=entries)
+
+        if len(resp["Successful"]) != len(entries):
+            raise RuntimeError(
+                f"Failed to delete messages: entries={entries!r} resp={resp!r}"
+            )
+
+
+def chunked_iterable(iterable, *, size):
+    it = iter(iterable)
+    while True:
+        chunk = tuple(itertools.islice(it, size))
+        if not chunk:
+            break
+        yield chunk
+
+
+if __name__ == "__main__":
+    src_queue_url = os.environ.get("DLQ_SQS_URL")
+    dst_queue_url = os.environ.get("SQS_DESTINATION_URL")
+
+    if src_queue_url == dst_queue_url:
+        sys.exit("Source and destination queues cannot be the same.")
+
+    sqs_client = boto3.client("sqs")
+
+    messages = get_messages_from_queue(sqs_client, queue_url=src_queue_url)
+
+    # The SendMessageBatch API supports sending up to ten messages at once.
+    for message_batch in chunked_iterable(messages, size=10):
+        print(f"Writing {len(message_batch):2d} messages to {dst_queue_url}")
+        sqs_client.send_message_batch(
+            QueueUrl=dst_queue_url,
+            Entries=[
+                {"Id": str(uuid.uuid4()), "MessageBody": message["Body"]}
+                for message in message_batch
+            ],
+        )

--- a/scripts/disaster_recovery/requirements.txt
+++ b/scripts/disaster_recovery/requirements.txt
@@ -1,0 +1,7 @@
+boto3==1.15.16
+botocore==1.18.16
+jmespath==0.10.0
+python-dateutil==2.8.1
+s3transfer==0.3.3
+six==1.15.0
+urllib3==1.25.10

--- a/scripts/process_dead_letter_queue
+++ b/scripts/process_dead_letter_queue
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -e -u -o pipefail
+
+echo "You are about to move messages from the dead letter queue to a active Functionbeat queue for re-processing."
+echo
+echo "Please enter AWS_SECRET_ACCESS_KEY"
+read
+secret_access_key=${REPLY}
+
+echo "Please enter AWS_ACCESS_KEY"
+read
+access_key=${REPLY}
+
+echo "Please enter Dead Letter SQS queue URL"
+read
+dlq_url=${REPLY}
+
+echo "Please enter destination SQS queue URL"
+read
+sqs_url=${REPLY}
+
+docker build -t dlq ./scripts/disaster_recovery
+
+docker run \
+  --env AWS_ACCESS_KEY_ID="${access_key}" \
+  --env AWS_SECRET_ACCESS_KEY="${secret_access_key}" \
+  --env DLQ_SQS_URL="${dlq_url}" \
+  --env AWS_DEFAULT_REGION="eu-west-2" \
+  --env SQS_DESTINATION_URL="${sqs_url}" -t dlq


### PR DESCRIPTION
This new makefile command will move the messages to an active queue so they
can be re-processed and sent to OST.

This script is only required to be run when there are messages in the
dead letter queue.