### PR TITLE
Syslog Client

### DIFF
--- a/modules/function_beats_config/main.tf
+++ b/modules/function_beats_config/main.tf
@@ -38,7 +38,6 @@ locals {
           subnet_ids : var.subnet_ids
         },
         triggers : local.syslog_log_group_map_array,
-        filter_pattern : "^(?!.*\"severity\": \"debug\").*$"
         processors : [
           {
             add_tags : {

--- a/modules/syslog_client/iam.tf
+++ b/modules/syslog_client/iam.tf
@@ -1,0 +1,25 @@
+resource "aws_iam_role" "syslog_client" {
+  name               = "syslog_client"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_policy.json
+}
+
+data "aws_iam_policy_document" "assume_role_policy" {
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "syslog_client" {
+  role       = aws_iam_role.syslog_client.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentAdminPolicy"
+}
+
+resource "aws_iam_instance_profile" "syslog_client" {
+  name = "syslog_client"
+  role = aws_iam_role.syslog_client.name
+}

--- a/modules/syslog_client/main.tf
+++ b/modules/syslog_client/main.tf
@@ -1,0 +1,78 @@
+data "template_file" "syslog_client" {
+  template = "${file("${path.module}/syslog_client.py")}"
+
+  vars = {
+    load_balancer_ip = var.load_balancer_ip
+  }
+}
+
+data "aws_ami" "amazon_linux2" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-2.0.20200617.0-x86_64-gp2"]
+  }
+
+  owners = ["137112412989"]
+}
+
+resource "aws_instance" "syslog_client" {
+  count                  = var.instance_count
+  ami                    = data.aws_ami.amazon_linux2.id
+  instance_type          = "t2.small"
+  vpc_security_group_ids = list(aws_security_group.syslog_client.id)
+  subnet_id              = var.subnet
+  associate_public_ip_address = true
+  iam_instance_profile = aws_iam_instance_profile.syslog_client.name
+
+  tags = {
+    Name = "${var.prefix}-syslog-test-client"
+  }
+
+  user_data = <<EOF
+#!/bin/bash -xe
+
+yum -y update
+yum install python3 awslogs -y
+
+systemctl start awslogsd
+
+mkdir ~/syslog_client
+echo '${data.template_file.syslog_client.rendered}' >> ~/syslog_client/syslog_client.py
+cd ~/syslog_client
+
+while true; do
+  python -c "import syslog_client; s = syslog_client.Syslog(); s.send({\"host\": \"Staff-Device-Syslog-Host\", \"ident\": \"1\", \"message\": \"Hello Syslog\", \"pri\": \"134\"}, syslog_client.Level.WARNING);"
+  sleep 1
+  echo "hi"
+done
+EOF
+}
+
+resource "aws_security_group" "syslog_client" {
+  name = "${var.prefix}-syslog-client-instance-security-group"
+
+  egress {
+    from_port   = 514
+    to_port     = 514
+    protocol    = "udp"
+    cidr_blocks = [var.vpc_cidr_block]
+  }
+
+  egress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  vpc_id = var.syslog_endpoint_vpc
+}

--- a/modules/syslog_client/syslog_client.py
+++ b/modules/syslog_client/syslog_client.py
@@ -1,0 +1,54 @@
+"""
+Remote syslog client
+"""
+
+import socket
+
+class Facility:
+    "Syslog facilities"
+    KERN, USER, MAIL, DAEMON, AUTH, SYSLOG, \
+        LPR, NEWS, UUCP, CRON, AUTHPRIV, FTP = range(12)
+
+    LOCAL0, LOCAL1, LOCAL2, LOCAL3, \
+        LOCAL4, LOCAL5, LOCAL6, LOCAL7 = range(16, 24)
+
+
+class Level:
+    "Syslog levels"
+    EMERG, ALERT, CRIT, ERR, \
+        WARNING, NOTICE, INFO, DEBUG = range(8)
+
+
+class Syslog:
+    """A syslog client that logs to a remote server.
+
+    Example:
+    >>> log = Syslog(host="foobar.example")
+    >>> log.send("hello", Level.WARNING)
+    """
+
+    def __init__(self,
+                 host="${load_balancer_ip}",
+                 port=514,
+                 facility=Facility.DAEMON):
+        self.host = host
+        self.port = port
+        self.facility = facility
+        self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+
+    def send(self, message, level):
+        data = "<%d>%s" % (level + self.facility*8, message)
+        result = self.socket.sendto(
+            data.encode("utf-8"), (self.host, self.port))
+
+    def warn(self, message):
+        "Send a syslog warning message."
+        self.send(message, Level.WARNING)
+
+    def notice(self, message):
+        "Send a syslog notice message."
+        self.send(message, Level.NOTICE)
+
+    def error(self, message):
+        "Send a syslog error message."
+        self.send(message, Level.ERR)

--- a/modules/syslog_client/variables.tf
+++ b/modules/syslog_client/variables.tf
@@ -1,0 +1,27 @@
+variable "instance_count" {
+  type = number
+}
+
+variable "prefix" {
+  type = string
+}
+
+variable "syslog_endpoint_vpc" {
+  type = string
+}
+
+variable "subnet" {
+  type = string
+}
+
+variable "load_balancer_ip" {
+  type = string
+}
+
+variable "tags" {
+  type = map(string)
+}
+
+variable "vpc_cidr_block" {
+  type = string
+}

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -6,6 +6,10 @@ output "private_subnets" {
   value = module.vpc.private_subnets
 }
 
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
 output "private_route_table_ids" {
   value = module.vpc.private_route_table_ids
 }

--- a/variables.tf
+++ b/variables.tf
@@ -98,7 +98,7 @@ variable "syslog_load_balancer_private_ip_eu_west_2c" {
 }
 
 variable "enable_transit_gateway_attachment" {
-  type = bool
+  type    = bool
   default = false
 }
 
@@ -119,6 +119,11 @@ variable "api_gateway_custom_domain" {
 }
 
 variable "enable_dlq" {
-  type = bool
+  type    = bool
+  default = false
+}
+
+variable "enable_syslog_endpoint_load_test" {
+  type    = bool
   default = false
 }


### PR DESCRIPTION
This will be used for load testing and as a heartbeat instance in the
future. The heartbeat instance will ensure syslogs are being sent to non
production environments so that alarms can be re-instated to monitor the
health of the platform for all environments.