### PR TITLE
Added message_retention_seconds value (7 days)  to dlq queue

### DIFF
--- a/modules/custom_logging_api/sqs.tf
+++ b/modules/custom_logging_api/sqs.tf
@@ -12,7 +12,7 @@ resource "aws_sqs_queue" "custom_log_queue" {
 
 resource "aws_sqs_queue" "dlq_custom_log_queue"{
   name = "${var.prefix}-dlq-custom-log-queue"
-
+  message_retention_seconds         = 604800
   kms_master_key_id                 = aws_kms_key.sqs_kms_master_key.key_id
   kms_data_key_reuse_period_seconds = 300
 }


### PR DESCRIPTION
## What

Increasing the message retention period on the dead letter queue.

## Why

To mitigate against public holidays.
