### PR TITLE
Don't ship the API Gateway execution logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -231,7 +231,6 @@ module "functionbeat_config" {
     "${module.label.id}-cloudtrail-log-group",
     "staff-device-${var.env}-dhcp-server-log-group",
     "/aws/rds/instance/staff-device-${var.env}-dhcp-db/audit",
-    module.customLoggingApi.log_group_name,
     "staff-device-${var.env}-dhcp-admin-log-group",
     "staff-device-${var.env}-dns-server-log-group",
     "staff-infra-${var.env}-ima-blackbox-exporter-cloudwatch-log-group",


### PR DESCRIPTION
These logs are generated by the API Gateway for each Firewall request we
receive from the Palo Altos. This results in roughly 70k additional logs
per minute to be shipped. This data sent is uninteresting and contains
information about the API request itself such as
"(536cd8e4-ef91-4266-9aa7-7a4a84ffb06f) Method completed with status:
200".

Don't send these logs to OST which reduces the number of logs shipped
significantly.