### PR TITLE
Make the syslog client script dynamic

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ env:
     TF_VAR_enable_transit_gateway_attachment: true
     TF_VAR_enable_api_gateway_custom_domain: true
     TF_VAR_enable_api_gateway_logs: true
+    TF_VAR_enable_syslog_endpoint_load_test: true
     TF_VAR_env: ${ENV}
   parameter-store:
     TF_VAR_enable_peering:                   "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/enable_peering"

--- a/modules/syslog_client/main.tf
+++ b/modules/syslog_client/main.tf
@@ -42,12 +42,7 @@ mkdir ~/syslog_client
 echo '${data.template_file.syslog_client.rendered}' >> ~/syslog_client/syslog_client.py
 cd ~/syslog_client
 
-count=0
-while true; do
-  python -c "import syslog_client; s = syslog_client.Syslog(); s.send({\"count\": \"$count\", \"host\": \"Staff-Device-Syslog-Host\", \"ident\": \"1\", \"message\": \"Hello Syslogs\", \"pri\": \"134\"}, syslog_client.Level.WARNING);"
-  sleep 1
-  ((count=count+1))
-done
+${var.heartbeat_script}
 EOF
 }
 

--- a/modules/syslog_client/variables.tf
+++ b/modules/syslog_client/variables.tf
@@ -25,3 +25,14 @@ variable "tags" {
 variable "vpc_cidr_block" {
   type = string
 }
+
+variable "heartbeat_script" {
+  default = <<EOF
+count=0
+while true; do
+  python -c "import syslog_client; s = syslog_client.Syslog(); s.send({\"count\": \"$count\", \"host\": \"Staff-Device-Syslog-Host\", \"ident\": \"1\", \"message\": \"Hello Syslogs\", \"pri\": \"134\"}, syslog_client.Level.WARNING);"
+  sleep 1
+  ((count=count+1))
+done
+EOF
+}


### PR DESCRIPTION
This allows the syslog client to be used as a heartbeat and a load test.
This will only be run on development and switched off ater the test has
been completed.