### PR TITLE
Subscribe to KEA standby and API log groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -230,6 +230,8 @@ module "functionbeat_config" {
     "PaloAltoNetworksFirewalls",
     "${module.label.id}-cloudtrail-log-group",
     "staff-device-${var.env}-dhcp-server-log-group",
+    "staff-device-${var.env}-dhcp-standby-server-log-group",
+    "staff-device-${var.env}-dhcp-api-server-log-group",
     "/aws/rds/instance/staff-device-${var.env}-dhcp-db/audit",
     "staff-device-${var.env}-dhcp-admin-log-group",
     "staff-device-${var.env}-dns-server-log-group",


### PR DESCRIPTION
Since introducing KEA HA, we have more log groups to monitor.
This will ship these new log groups to OST.