### PR TITLE
Update links pointing to renamed shared services repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the Log Shipping infrastructure used by the [Ministry of Justice](https:
 
 This repository defines the **system infrastructure only**. Specific components and applications are defined in their own logical external repositories.
 
-- [Shared Services](https://github.com/ministryofjustice/pttp-shared-services-infrastructure)
+- [Shared Services](https://github.com/ministryofjustice/staff-device-shared-services-infrastructure)
 - [Syslog to Cloudwatch](https://github.com/ministryofjustice/staff-device-logging-syslog-to-cloudwatch)
 
 Below you will find various documentation about managing and running this service:

--- a/documentation/deployment.md
+++ b/documentation/deployment.md
@@ -10,9 +10,9 @@ There are 3 AWS environments that run this service. Each one in a separate AWS a
 2. Pre-production
 3. Production
 
-The environments are deployed from a [Shared Services](https://github.com/ministryofjustice/pttp-shared-services-infrastructure) AWS account by assuming a [pre-defined IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) into the target account.
+The environments are deployed from a [Shared Services](https://github.com/ministryofjustice/staff-device-shared-services-infrastructure) AWS account by assuming a [pre-defined IAM role](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) into the target account.
 
-The [source code](https://github.com/ministryofjustice/pttp-shared-services-infrastructure) for the pipeline is available on Github.
+The [source code](https://github.com/ministryofjustice/staff-device-shared-services-infrastructure) for the pipeline is available on Github.
 
 Each deploy is immutable and installs the dependencies from scratch in a new build container.
 

--- a/documentation/sending_new_logs_to_ost.md
+++ b/documentation/sending_new_logs_to_ost.md
@@ -16,7 +16,7 @@ Cross-account log subscriptions need to be backed by [Kinesis](https://aws.amazo
 
 Same account log subscriptions are managed in Terraform, and adding a new log group from the same AWS account can be done by adding it to the variable called `log_groups` for the `functionbeat` module in the [main.tf](../main.tf) file.
 
-Cross account log subscriptions are managed in the Shared Services Terraform code [repository](https://github.com/ministryofjustice/pttp-shared-services-infrastructure/tree/master/modules/log-forwarding).
+Cross account log subscriptions are managed in the Shared Services Terraform code [repository](https://github.com/ministryofjustice/staff-device-shared-services-infrastructure/tree/master/modules/log-forwarding).
 
 Given the service ships log groups not created by this Terraform repo, not all log group names can be derived dynamically from Terraform resources. All CloudTrail logs in the AWS account are forwarded to CloudWatch, and then shipped.
 


### PR DESCRIPTION
pttp was replaced with staff-device as the prefix for this repo for
consistency. Update links pointing to this repo in the README