### PR TITLE
Changing the functionbeat output to logstash

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,6 +25,7 @@ env:
     TF_VAR_ost_username:                     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_username"
     TF_VAR_ost_password:                     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_password"
     TF_VAR_ost_url:                          "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_url"
+    TF_VAR_ost_logstash_url:                 "/codebuild/pttp-ci-infrastructure-core-pipeline/development/ost_logstash_url"
     TF_VAR_critical_notification_recipients: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/critical_notification_recipients"
     TF_VAR_api_gateway_custom_domain:        "/staff-device/$ENV/logging/api_gateway_domain_name"
     # function beats related config

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,7 +25,7 @@ env:
     TF_VAR_ost_username:                     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_username"
     TF_VAR_ost_password:                     "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_password"
     TF_VAR_ost_url:                          "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_url"
-    TF_VAR_ost_logstash_url:                 "/codebuild/pttp-ci-infrastructure-core-pipeline/development/ost_logstash_url"
+    TF_VAR_ost_logstash_url:                 "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/ost_logstash_url"
     TF_VAR_critical_notification_recipients: "/codebuild/pttp-ci-infrastructure-core-pipeline/$ENV/critical_notification_recipients"
     TF_VAR_api_gateway_custom_domain:        "/staff-device/$ENV/logging/api_gateway_domain_name"
     # function beats related config

--- a/main.tf
+++ b/main.tf
@@ -223,9 +223,10 @@ module "functionbeat_config" {
     module.syslog_endpoint.logging.syslog_log_group_name
   ]
 
-  destination_url      = var.ost_url
-  destination_username = var.ost_username
-  destination_password = var.ost_password
+  destination_url              = var.ost_url
+  destination_url_logstash     = var.ost_logstash_url
+  destination_username         = var.ost_username
+  destination_password         = var.ost_password
 }
 
 module "firewall_roles" {

--- a/modules/function_beats_config/main.tf
+++ b/modules/function_beats_config/main.tf
@@ -168,18 +168,8 @@ locals {
     "logging.level" : "warning"
     "output.logstash" : {
       hosts: [var.destination_url_logstash]
-     }
-    # "output.elasticsearch" : {
-    #   hosts : [var.destination_url]
-    #   protocol : "https"
-    #   username : var.destination_username
-    #   password : var.destination_password
-    #   index : "functionbeat-%%{[agent.version]}"
-    # }
-    # "output.elasticsearch.ssl.certificate_authorities" : ["elk-ca.crt"]
-    # "output.elasticsearch.ssl.certificate" : "moj.crt"
-    # "output.elasticsearch.ssl.key" : "moj.key"
-
+    }
+     
     "logging.level" : "info"
 
     processors : [

--- a/modules/function_beats_config/main.tf
+++ b/modules/function_beats_config/main.tf
@@ -166,16 +166,20 @@ locals {
     "setup.template.pattern" : "functionbeat-%%{[agent.version]}-*"
     "setup.ilm.enabled" : false
     "logging.level" : "warning"
-    "output.elasticsearch" : {
-      hosts : [var.destination_url]
-      protocol : "https"
-      username : var.destination_username
-      password : var.destination_password
-      index : "functionbeat-%%{[agent.version]}"
-    }
-    "output.elasticsearch.ssl.certificate_authorities" : ["elk-ca.crt"]
-    "output.elasticsearch.ssl.certificate" : "moj.crt"
-    "output.elasticsearch.ssl.key" : "moj.key"
+    "output.logstash" : {
+      hosts: [var.ost_logstash_url]
+     }
+    # "output.elasticsearch" : {
+    #   hosts : [var.destination_url]
+    #   protocol : "https"
+    #   username : var.destination_username
+    #   password : var.destination_password
+    #   index : "functionbeat-%%{[agent.version]}"
+    # }
+    # "output.elasticsearch.ssl.certificate_authorities" : ["elk-ca.crt"]
+    # "output.elasticsearch.ssl.certificate" : "moj.crt"
+    # "output.elasticsearch.ssl.key" : "moj.key"
+
     "logging.level" : "info"
 
     processors : [

--- a/modules/function_beats_config/main.tf
+++ b/modules/function_beats_config/main.tf
@@ -167,7 +167,7 @@ locals {
     "setup.ilm.enabled" : false
     "logging.level" : "warning"
     "output.logstash" : {
-      hosts: [var.ost_logstash_url]
+      hosts: [var.destination_url_logstash]
      }
     # "output.elasticsearch" : {
     #   hosts : [var.destination_url]

--- a/modules/function_beats_config/variables.tf
+++ b/modules/function_beats_config/variables.tf
@@ -19,6 +19,10 @@ variable "subnet_ids" {
 variable "destination_url" {
   type = string
 }
+
+variable "destination_url_logstash" {
+  type = string
+}
 variable "destination_username" {
   type = string
 }

--- a/modules/logging/beats.tf
+++ b/modules/logging/beats.tf
@@ -165,6 +165,13 @@ resource "aws_security_group" "functionbeats" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+    egress {
+    from_port   = 5044
+    to_port     = 5044
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 443
     to_port     = 443

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,10 @@ variable "ost_url" {
   type = string
 }
 
+variable "ost_logstash_url" {
+  type = string
+}
+
 variable "critical_notification_recipients" {
   type = list(string)
 }


### PR DESCRIPTION
This PR changes the output type from elasticsearch to logstash in the functionbeats config.  It also adds an egress rule in a security group to allow outbound on port 5044.