### PR TITLE
Don't track the RDS audit log

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -235,7 +235,6 @@ module "functionbeat_config" {
     "mojo-${var.env}-nac-server-log-group",
     "mojo-${var.env}-nac-admin-log-group",
     "mojo-${var.env}-nac-vpc-flow-logs-log-group",
-    "/aws/rds/instance/mojo-${var.env}-nac-admin-db/audit",
     "/aws/rds/instance/mojo-${var.env}-nac-admin-read-replica/error"
   ]
 


### PR DESCRIPTION
Since upgrading to Mysql 8.0, this log data is not avaiable.
Temporary fix here until we can go back to mysql engine version 5.7