### PR TITLE
Revert ":arrow_up: Upgrade functionbeats to 7.14.0"

### DIFF
--- a/scripts/install_functionbeat
+++ b/scripts/install_functionbeat
@@ -2,7 +2,7 @@
 
 set -e -u -o pipefail
 
-wget --no-verbose -O functionbeat.tar.gz https://artifacts.elastic.co/downloads/beats/functionbeat/functionbeat-7.14.0-linux-x86_64.tar.gz
+wget --no-verbose -O functionbeat.tar.gz https://artifacts.elastic.co/downloads/beats/functionbeat/functionbeat-7.9.3-linux-x86_64.tar.gz
 
 tar -xzf functionbeat.tar.gz
 mv functionbeat-*-linux-x86_64 functionbeat


### PR DESCRIPTION
Reverts ministryofjustice/staff-device-logging-infrastructure#38

Caused error in pipeline

`error while finding enabled functions: invalid name: 'staff-device-development-infra-cloudwatch-syslog', name must match [a-zA-Z0-9-] and be at most 30 characters accessing 'functionbeat.provider.aws.functions.0.name' (source:'../functionbeat-config.yml')`