### PR TITLE
:recycle: rename functions to pass new validation rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -205,6 +205,7 @@ module "functionbeat_config" {
   source = "./modules/function_beats_config"
 
   prefix                  = module.label.id
+  env                     = var.env
   deploy_bucket           = module.logging.beats_deploy_bucket
   deploy_role_arn         = module.logging.beats_role_arn
   deploy_role_kinesis_arn = module.logging.beats_role_kinesis_arn

--- a/modules/function_beats_config/main.tf
+++ b/modules/function_beats_config/main.tf
@@ -10,10 +10,10 @@ locals {
     }
   ]
 
-  cloudwatch_syslog_name         = "${var.prefix}-cloudwatch-syslog"
-  cloudwatch_name                = "${var.prefix}-cloudwatch"
-  sqs_name                       = "${var.prefix}-sqs"
-  kinesis_name                   = "${var.prefix}-kinesis"
+  cloudwatch_syslog_name         = "${var.env}-cw-syslog"
+  cloudwatch_name                = "${var.env}-cw"
+  sqs_name                       = "${var.env}-sqs"
+  kinesis_name                   = "${var.env}-kinesis"
 
   config = yamlencode({
     "functionbeat.provider.aws.endpoint" : "s3.amazonaws.com"

--- a/modules/function_beats_config/variables.tf
+++ b/modules/function_beats_config/variables.tf
@@ -1,6 +1,10 @@
 variable "prefix" {
   type = string
 }
+
+variable "env" {
+  type = string
+}
 variable "deploy_bucket" {
   type = string
 }


### PR DESCRIPTION
As a prerequisite to upgrading to 7.14.0 the names o the functions must be less than 30 characters.