### PR TITLE
:bookmark: add tags to kinesis and sqs resources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -263,6 +263,7 @@ module "shared_services_log_destination" {
   region                                 = data.aws_region.current_region.id
   shared_services_account_arn            = data.aws_caller_identity.shared_services_account.account_id
   enable_shared_services_log_destination = var.enable_shared_services_log_destination
+  tags                                   = module.label.tags
 
   providers = {
     aws = aws.env

--- a/modules/custom_logging_api/sqs.tf
+++ b/modules/custom_logging_api/sqs.tf
@@ -8,6 +8,8 @@ resource "aws_sqs_queue" "custom_log_queue" {
     deadLetterTargetArn = aws_sqs_queue.dlq_custom_log_queue.arn
     maxReceiveCount     = 5
   })
+
+  tags = var.tags
 }
 
 resource "aws_sqs_queue" "dlq_custom_log_queue"{

--- a/modules/shared_services_log_destination_stream/main.tf
+++ b/modules/shared_services_log_destination_stream/main.tf
@@ -9,6 +9,7 @@ resource "aws_kinesis_stream" "shared_services_destination_stream" {
   encryption_type  = "KMS"
   kms_key_id       = aws_kms_key.kinesis_stream_key.id
   retention_period = 168
+  tags             = var.tags
 
   shard_level_metrics = [
     "IncomingBytes",

--- a/modules/shared_services_log_destination_stream/variables.tf
+++ b/modules/shared_services_log_destination_stream/variables.tf
@@ -13,3 +13,7 @@ variable "shared_services_account_arn" {
 variable "enable_shared_services_log_destination" {
   type = bool
 }
+
+variable "tags" {
+  type = map(string)
+}


### PR DESCRIPTION
In order to monitor resources using Cloudwatch Exporter and Prometheus, they must be tagged.  This PR will add tags to the kinesis and SQS resources in aws.