### PR TITLE
:bookmark: Correct apiGateway tagging

### DIFF
--- a/modules/api_gateway_load_test/variables.tf
+++ b/modules/api_gateway_load_test/variables.tf
@@ -25,3 +25,7 @@ variable "prefix" {
 variable "enable_load_testing" {
   type = bool
 }
+
+variable "tags" {
+  type = map(string)
+}

--- a/modules/custom_logging_api/apiGateway.tf
+++ b/modules/custom_logging_api/apiGateway.tf
@@ -29,7 +29,6 @@ resource "aws_api_gateway_resource" "proxy" {
   rest_api_id = aws_api_gateway_rest_api.logging_gateway.id
   parent_id   = aws_api_gateway_rest_api.logging_gateway.root_resource_id
   path_part   = "logs"
-  tags        = var.tags
 }
 
 resource "aws_api_gateway_method" "proxy" {


### PR DESCRIPTION
Rectifies errors which appeared when pushing [this ](https://github.com/ministryofjustice/staff-device-logging-infrastructure/commit/8eaf35c2e66def44b1906dd1e6cd249f7b757a6a) commit. 