### PR TITLE
:coffin: Remove tagging from 'vpc' module

### DIFF
--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -31,6 +31,4 @@ module "vpc" {
   public_subnets = [
     cidrsubnet(var.cidr_block, 6, 4)
   ]
-
-  tags = var.tags
 }

--- a/modules/vpc/variables.tf
+++ b/modules/vpc/variables.tf
@@ -59,7 +59,3 @@ variable "enable_logs_endpoint" {
   type    = bool
   default = false
 }
-
-variable "tags" {
-  type = map(string)
-}


### PR DESCRIPTION
The use of tags caused vpc's to show in the console with the same name, removing this tag (as is the case in the DNS/DHCP infrastructure) should rectify this.